### PR TITLE
using kwargs instead of positional

### DIFF
--- a/hentai/hentai.py
+++ b/hentai/hentai.py
@@ -284,7 +284,9 @@ class RequestHandler(object):
         factor. It is used in the session property where these values are 
         passed to the HTTPAdapter. 
         """
-        return Retry(self.total, self.status_forcelist, self.backoff_factor)
+        return Retry(total=self.total,
+                     status_forcelist=self.status_forcelist,
+                     backoff_factor=self.backoff_factor)
 
     @property
     def session(self) -> Session:


### PR DESCRIPTION
I was getting an error on hentai.download() and after a bit of debugging I found that the use of positional arguments messes things us. The Retry initializer takes these arguments in a different order that the ones given, so changing them to keyword argument fixes the error. Also it's backward compatible.

The error I was getting was
return min(timeout) < 0:
not supported '<' between list and tuple