### PR TITLE
Final Release Candidate v3.2.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+- name: Feature Request?
+  url: https://github.com/hentai-chan/hentai/discussions/53
+  about: Please open these under `hentai/discussions`.
+- name: Security Policy
+  url: https://github.com/hentai-chan/hentai/blob/master/SECURITY.md
+  about: Please learn how to report security vulnerabilities here.
+- name: Code of Conduct
+  url: https://github.com/hentai-chan/hentai/blob/master/CODE_OF_CONDUCT.md
+  about: For all Code of Conduct related matters, please refer to this document.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "pip"
@@ -10,3 +5,12 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "rec-hentai"
+    labels:
+      - "triage-required"
+      - "dependencies"
+    commit-message:
+      prefix: "[MAINT]"
+    assignees:
+      - "hentai-chan"
+    reviewers:
+      - "hentai-chan"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: CI
 
 on:
@@ -18,11 +15,11 @@ on:
 
 jobs:
   build:
-
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10.0-beta.1 ]
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v2
@@ -44,4 +41,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run unit tests
       run: |
-        pytest --verbose
+        pytest --verbose -s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,34 @@
 # Changelog
 
+## Version 3.2.6 (15 May 2021)
+
+Extends continuous integration scripts by running unit tests on all major platforms
+and recent versions of python - the version matrix now also includes `3.10-beta.1`!
+
+Note that this update also redefines the built-in CLI:
+
+```bash
+# now supports queued downloads! (turn on the progress bar with the verbose flag)
+hentai --verbose download --id 1 2 3
+
+# print title, genre, lang and num_pages (also supports multiple args)
+hentai preview --id 177013
+```
+
+More importantly, this update also removes `requests_html` and `colorama` from the
+list of required project dependencies, making this library more lightweight and
+faster to install. Lastly, a security policy is now in place for disclosing
+security vulnerabilities. Head over to this project's
+[security policy](https://github.com/hentai-chan/hentai/blob/master/SECURITY.md)
+to learn more about recommended security guidelines that you can follow while
+developing your applications.
+
 ## Version 3.2.5 (26 February 2021)
 
 Updates the documentation and moves the log file path on Linux back to `~/.hentai`,
-but also improves the contributing notes for developers.
+but also improves the
+[contributing notes](https://github.com/hentai-chan/hentai/blob/master/CONTRIBUTING.md)
+for developers.
 
 ## Version 3.2.4 (09 February 2021)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
         <img src="https://codecov.io/gh/hentai-chan/hentai/branch/master/graph/badge.svg?token=HOE2YZO4V6"/>
     </a>
     <a title="Supported Python Versions">
-        <img src="https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9-blue">
+        <img src="https://img.shields.io/pypi/pyversions/hentai">
     </a>
     <a href="https://www.gnu.org/licenses/gpl-3.0.en.html" title="License Information" target="_blank">
         <img src="https://img.shields.io/badge/License-GPLv3-blue.svg">
@@ -58,7 +58,7 @@ this module to make an unreasonable amount of requests in a short period of time
 Get the most recent stable release from PyPI:
 
 ```bash
-pip install hentai
+pip install hentai --only-binary all
 ```
 
 <details>
@@ -76,7 +76,7 @@ pip install -r requirements.txt
 # additionally install the following dependencies
 pip install flake8 pytest wheel
 # run all unit tests
-pytest --verbose
+pytest --verbose -s
 # create wheel
 python setup.py bdist_wheel --universal
 ```
@@ -161,13 +161,13 @@ doujins within the terminal:
 
 ```cli
 # get help
-hentai -h
+hentai --help
 
 # download this doujin to the CWD
-hentai -id 177013
+hentai --verbose download --id 177013
 
 # check the module version
-hentai -version
+hentai --version
 ```
 
 ## Get In Touch

--- a/README.zh.md
+++ b/README.zh.md
@@ -28,7 +28,7 @@
         <img src="https://codecov.io/gh/hentai-chan/hentai/branch/master/graph/badge.svg?token=HOE2YZO4V6"/>
     </a>
     <a title="Supported Python Versions">
-        <img src="https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9-blue">
+        <img src="https://img.shields.io/pypi/pyversions/hentai">
     </a>
     <a href="https://www.gnu.org/licenses/gpl-3.0.en.html" title="License Information" target="_blank">
         <img src="https://img.shields.io/badge/License-GPLv3-blue.svg">
@@ -55,7 +55,7 @@
 从 PyPI 取得最新的稳定版本:
 
 ```bash
-pip install hentai
+pip install hentai --only-binary all
 ```
 
 <details>
@@ -73,7 +73,7 @@ pip install -r requirements.txt
 # 另请安装以下依赖类型
 pip install flake8 pytest wheel
 # 执行全部单元测试
-pytest --verbose
+pytest --verbose -s
 # 创造 wheel
 python setup.py bdist_wheel --universal
 ```
@@ -149,15 +149,16 @@ Utils.export(popular_loli, filename=Path('popular_loli.json'), options=custom)
 ## 指令列介面
 
 自版本3.2.4起，本模组也提供基本的指令列介面以从在终端里下载同人誌：
+
 ```cli
 # 取得帮助
-hentai -h
+hentai --help
 
 # 将此同人下载到CWD
-hentai -id 177013
+hentai --verbose download --id 177013
 
 # 查看模组版本
-hentai -version
+hentai --version
 ```
 
 ## 取得联系

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+<p align="center">
+  <a title="Project Logo">
+    <img height="150" style="margin-top:15px" src="https://raw.githubusercontent.com/Advanced-Systems/vector-assets/master/advanced-systems-logo-annotated.svg">
+  </a>
+</p>
+
+<h1 align="center">Advanced Systems Security Policy</h1>
+
+## Python Package Distribution
+
+Installing third-party packages from PyPI always bears a certain risk: Source
+distributions for instance are capable of running arbitrary code during the
+installation procedure. By default, PIP attempts to install packages using wheels
+if they are available (inter alia to circumvent the attack vector of arbitrary
+code execution), but it will always fall back to source distributions if the
+package doesn't provide any form of binary distribution. Different threat models
+require different forms of protections, but this doesn't alter the fact that even
+safe guards like the web of trust (WoT) only offer limited protection as in theory
+anyone is qualified to become a package maintainer on PyPI, and even then end users
+are vulnerable to typosquatting for all it takes is a moment of inadvertence to
+accidentally install malware on their machine. As a rule of thumb, it is strongly
+recommended to never run `pip` with root privileges. Use virtual environments to
+isolate package installs for each individual project.
+
+## DevSecOps Measures in Place
+
+This project uses CodeQL that runs a static code analysis on each submission made
+to this repository to detect malicious contributions before they creep into the
+final release. CodeQL uses code queries created by a community of security
+researchers on GitHub to help detect known security vulnerabilities in open-source
+projects by following recommended security guidelines in all lines of works.
+
+On top of that, dependatbot alerts are integrated in a pipeline of automated security
+checks to help identify security vulnerabilities in dependencies.
+
+By installing Python packages from PyPI you implicitly choose to trust not only
+the repository owner, but anyone that is authorized to create new releases. In
+the open-source software community it is therefore important to maintain a watchful
+eye on compliance from any participating contributing party.
+
+## Report A Vulnerability
+
+Please email `dev.hentai-chan@outlook.com` to report any security-related issues
+and include the following information in the text body:
+
+- Your name and affiliation (if any)
+- A description of the technical details of the vulnerabilities along with a step-by-step
+  guide to help us reproduce your findings
+- An explanation who can exploit this vulnerability, and what they gain when doing so
+- Whether this vulnerability public or known to third parties

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
 -r release.txt
-pretty-errors==1.2.19
+pretty-errors==1.2.20
 check-manifest==0.46

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,3 +1,3 @@
 tqdm==4.58.0
 requests==2.25.1
-Faker==8.1.3
+Faker==8.1.4

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,3 +1,3 @@
-tqdm==4.58.0
+tqdm==4.60.0
 requests==2.25.1
 Faker==8.1.4

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,5 +1,3 @@
-colorama==0.4.4
 tqdm==4.58.0
 requests==2.25.1
-requests_html==0.10.0
-Faker==6.5.0
+Faker==8.1.3

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Operating System :: OS Independent',
         'Topic :: Education',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',

--- a/src/hentai/__init__.py
+++ b/src/hentai/__init__.py
@@ -1,16 +1,55 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
+from pathlib import Path
+
+from requests import HTTPError
 
 from .hentai import *
 from .hentai import __version__
 
+
 def main():
     parser = argparse.ArgumentParser(prog=package_name)
-    parser.add_argument('-id', type=int, help="download this doujin in the current working directory")
-    parser.add_argument('-version', action='version', version=f"%(prog)s {__version__}")
+    parser._positionals.title = 'Commands'
+    parser._optionals.title = 'Arguments'
+
+    parser.add_argument('-v', '--version', action='version', version=f"%(prog)s {__version__}")
+    parser.add_argument('-V', '--verbose', action='store_true', help="increase output verbosity")
+
+    subparser = parser.add_subparsers(dest='command')
+
+    download_parser = subparser.add_parser('download', help="download doujin (CWD by default)")
+    download_parser.add_argument('--id', type=int, nargs='+', required=True, help="magic number")
+    download_parser.add_argument('--dest', type=Path, default=Path.cwd(), help="download directory (CWD by default)")
+
+    preview_parser = subparser.add_parser('preview', help="print doujin preview")
+    preview_parser.add_argument('--id', type=int, nargs='+', required=True, help="magic number")
+
     args = parser.parse_args()
-    Hentai(args.id).download(progressbar=True)
+    
+    if args.command == 'download':
+        count = len(args.id)
+        for id_ in args.id:
+            try:
+                doujin = Hentai(id_)
+                doujin.download(dest=args.dest, progressbar=args.verbose)
+            except HTTPError as error:
+                print(f"\033[31mDownloadError:\033[0m {error}", file=sys.stderr)
+                count -= 1
+        if count: print(f"Stored {count} doujin{'s' if count > 1 else ''} in {str(args.dest)!r}")
+
+    if args.command == 'preview':
+        for id_ in args.id:
+            try:
+                doujin = Hentai(id_)
+                print(f"\033[32m{doujin.title(Format.Pretty)!r} by {Tag.get(doujin.artist, 'name')}\033[0m")
+                print(f"genres:\t{Tag.get(doujin.tag, 'name')}")
+                print(f"langs:\t{Tag.get(doujin.language, 'name')}")
+                print(f"pages:\t{doujin.num_pages}", end='\n\n' if id_ != len(args.id) else '')
+            except HTTPError as error:
+                print(f"\033[31mPreviewError:\033[0m {error}", file=sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,8 +18,7 @@ class TestUtils(unittest.TestCase):
     
     @classmethod
     def tearDownClass(cls):
-        # missing_ok=True is only available in python 3.8+
-        remove_file = lambda file: Path(file).unlink()
+        remove_file = lambda file: Path(file).unlink() if Path(file).exists() else None
         remove_dir = lambda dir: shutil.rmtree(dir, ignore_errors=True)
 
         remove_file(cls.tiny_evil_file)
@@ -36,7 +35,7 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(response.ok, msg=f"Failing ID: {random_hentai.id}. Failing URL: {response.url}")
 
     def test_download_queue(self):
-        Utils.download([self.tiny_evil])
+        Utils.download([self.tiny_evil], progressbar=True)
         self.assertTrue(self.tiny_evil_dir.is_dir())
 
     def test_get_homepage(self):


### PR DESCRIPTION
## Version 3.2.6 (15 May 2021)

Extends continuous integration scripts by running unit tests on all major platforms and recent versions of python - the version matrix now also includes `3.10-beta.1`!

Note that this update also redefines the built-in CLI:

```bash
# now supports queued downloads! (turn on the progress bar with the verbose flag)
hentai --verbose download --id 1 2 3

# print title, genre, lang and num_pages (also supports multiple args)
hentai preview --id 177013
```

More importantly, this update also removes `requests_html` and `colorama` from the list of required project dependencies, making this library more lightweight and faster to install. Lastly, a security policy is now in place for disclosing security vulnerabilities. Head over to this project's security policy](https://github.com/hentai-chan/hentai/blob/master/SECURITY.md) to learn more about recommended security guidelines that you can follow while developing your applications.