### PR TITLE
Remove unavailable endpoint Sort.PopularYear

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ fork this repository and run
 
 ```bash
 python -m venv venv/
-source venv/bin/activate
+source venv/bin/activate # For Windows: .\venv\Scripts\activate
 python -m pip install --upgrade pip
-pip install -r requirements.txt
+pip install -r requirements/dev.txt
 # additionally install the following dependencies
 pip install flake8 pytest wheel
 # run all unit tests

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,9 +67,9 @@ pip install hentai --only-binary all
 
 ```bash
 python -m venv venv/
-source venv/bin/activate
+source venv/bin/activate # Windows: .\venv\Scripts\activate
 python -m pip install --upgrade pip
-pip install -r requirements.txt
+pip install -r requirements/dev.txt
 # 另请安装以下依赖类型
 pip install flake8 pytest wheel
 # 执行全部单元测试

--- a/src/hentai/hentai.py
+++ b/src/hentai/hentai.py
@@ -324,7 +324,6 @@ class Sort(Enum):
     Expose endpoints used to sort queries. Defaults to `Popular`.
     """
     Popular = 'popular'
-    PopularYear = 'popular-year'
     PopularMonth = 'popular-month'
     PopularWeek = 'popular-week'
     PopularToday = 'popular-today'


### PR DESCRIPTION
Found that Sort.PopularYear (popular-year) has no effect. Suggest to remove the option.  
Also updated the README.md about contributor setup

To reproduce, see this commit https://github.com/ttdyce/hentai/commit/75836a855644ba5f4a5a1d266dc95b638fa625c4  
and run: `pytest -rP tests/test_utils.py::TestUtils::test_PopularYear`  

_The test shows that Sort.PopularYear seems to be the same with Sort.Date_
![image](https://user-images.githubusercontent.com/34944417/148563734-b2b337ec-2ba5-46ee-ae8b-8affce097056.png)

